### PR TITLE
logsを無視

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ node_modules
 
 # Generated images
 /backend/saves/images/generated/
+
+# Runtime logs
+/backend/logs/

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,7 +14,7 @@ import { Scheduler } from './services/scheduler/client.js';
 import { TwitterClient } from './services/twitter/client.js';
 import { WebClient } from './services/web/client.js';
 import { YoutubeClient } from './services/youtube/client.js';
-import { logger } from './utils/logger.js';
+import { logger, initFileLogging } from './utils/logger.js';
 
 class Server {
   private llmService: LLMService;
@@ -248,6 +248,10 @@ class Server {
 
   public async start() {
     try {
+      // ファイルログを有効化（ANSI除去済みのプレーンテキストで保存）
+      const logsDir = new URL('../logs', import.meta.url).pathname;
+      initFileLogging(logsDir);
+
       // HTTPサーバーを最初に起動
       this.startHTTPServer();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds non-critical log output and a new startup call; main risk is disk/permission issues or unexpected log volume in production.
> 
> **Overview**
> Backend logging now supports **optional file output**: a new `initFileLogging(dir)` enables writing all `logger.*` lines to plain-text daily files (`prod-YYYYMMDD.log`) with automatic rotation at JST midnight and ANSI codes stripped.
> 
> `Server.start()` initializes file logging to `backend/logs`, and `.gitignore` now ignores `backend/logs/` so runtime log files aren’t committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07d7ba37dd4a5b733769fc3e0e45be6b88d798c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->