### PR TITLE
fix: uploadMedia retry on session expiry

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -106,7 +106,7 @@ export const config = {
     /** ポーリング間隔 (ミリ秒) */
     monitorIntervalMs: parseInt(optional('TWITTER_MONITOR_INTERVAL_MS', '1800000'), 10),
     /** 自動投稿: 1日あたりの最大投稿数 */
-    maxAutoPostsPerDay: parseInt(optional('TWITTER_MAX_AUTO_POSTS_PER_DAY', '8'), 10),
+    maxAutoPostsPerDay: parseInt(optional('TWITTER_MAX_AUTO_POSTS_PER_DAY', '10'), 10),
     /** 自動投稿: 活動開始時間 (JST, 0-23) */
     autoPostStartHour: parseInt(optional('TWITTER_AUTO_POST_START_HOUR', '8'), 10),
     /** 自動投稿: 活動終了時間 (JST, 0-24) */


### PR DESCRIPTION
セッション切れ時にloginV2で再ログインしてリトライ

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Twitter posting infrastructure by adding automatic re-login and retry behavior, which could cause duplicate uploads or extra login traffic if error detection is too broad, but the change is scoped and single-retry guarded.
> 
> **Overview**
> Improves robustness of Twitter media uploads by adding a **single re-login + retry** path in `TwitterClient.uploadMedia` when the upload response indicates failure or an Axios error occurs (with clearer error extraction and retry logging).
> 
> Also increases the default `TWITTER_MAX_AUTO_POSTS_PER_DAY` from `8` to `10` in `config`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad925326d20b5848802cb4c3e163081edf77bbbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->