### PR TITLE
release: uploadMedia retry fix

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -106,7 +106,7 @@ export const config = {
     /** ポーリング間隔 (ミリ秒) */
     monitorIntervalMs: parseInt(optional('TWITTER_MONITOR_INTERVAL_MS', '1800000'), 10),
     /** 自動投稿: 1日あたりの最大投稿数 */
-    maxAutoPostsPerDay: parseInt(optional('TWITTER_MAX_AUTO_POSTS_PER_DAY', '8'), 10),
+    maxAutoPostsPerDay: parseInt(optional('TWITTER_MAX_AUTO_POSTS_PER_DAY', '10'), 10),
     /** 自動投稿: 活動開始時間 (JST, 0-23) */
     autoPostStartHour: parseInt(optional('TWITTER_AUTO_POST_START_HOUR', '8'), 10),
     /** 自動投稿: 活動終了時間 (JST, 0-24) */


### PR DESCRIPTION
uploadMediaのセッション切れ時リトライ追加

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Twitter posting infrastructure by changing media upload error handling and introducing automatic re-login retries, which could affect upload behavior under auth/API failure conditions.
> 
> **Overview**
> Improves Twitter media uploads by adding a one-time retry path in `TwitterClient.uploadMedia`: on API/axios failures it now re-runs `loginV2()` and retries the upload, with clearer error extraction (`msg`/`message`) and retry-aware logging.
> 
> In config, increases the default `TWITTER_MAX_AUTO_POSTS_PER_DAY` fallback from `8` to `10`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d556032d206981e3622a76ed71bd9758d532353b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->