### PR TITLE
fix: KPI カードのデータ取得を修正

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -121,6 +121,31 @@ class Server {
       res.json(await tokenTracker.getDailyStats(days));
     });
 
+    app.get('/api/tokens/today', async (_req, res) => {
+      const daily = await tokenTracker.getDailyStats(1);
+      const todayTotal = daily.reduce((sum: number, d: any) => sum + (d.totalTokens || 0), 0);
+      const todayCalls = daily.reduce((sum: number, d: any) => sum + (d.calls || 0), 0);
+      res.json({ totalTokens: todayTotal, callCount: todayCalls, details: daily });
+    });
+
+    // -----------------------------------------------------------------
+    // 投稿スケジュール API
+    // -----------------------------------------------------------------
+    app.get('/api/twitter/schedule', (_req, res) => {
+      try {
+        const fs = require('fs');
+        const schedulePath = require('path').resolve('saves/auto_post_daily_schedule.json');
+        if (fs.existsSync(schedulePath)) {
+          const data = JSON.parse(fs.readFileSync(schedulePath, 'utf-8'));
+          res.json(data);
+        } else {
+          res.json({ date: '', times: [], postedCount: 0 });
+        }
+      } catch {
+        res.json({ date: '', times: [], postedCount: 0 });
+      }
+    });
+
     // -----------------------------------------------------------------
     // Twitter Webhook: twitterapi.io からのリアルタイム返信通知を受信
     // -----------------------------------------------------------------

--- a/frontend/src/components/KPICards/KPICards.tsx
+++ b/frontend/src/components/KPICards/KPICards.tsx
@@ -20,9 +20,10 @@ export const KPICards: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [healthRes, tokenRes] = await Promise.allSettled([
+        const [healthRes, tokenRes, scheduleRes] = await Promise.allSettled([
           fetch('/api/health').then(r => r.json()),
-          fetch('/api/tokens/session').then(r => r.json()),
+          fetch('/api/tokens/today').then(r => r.json()),
+          fetch('/api/twitter/schedule').then(r => r.json()),
         ]);
 
         setCards(prev => {
@@ -34,7 +35,13 @@ export const KPICards: React.FC = () => {
           if (tokenRes.status === 'fulfilled') {
             const data = tokenRes.value;
             const totalK = data.totalTokens ? `${(data.totalTokens / 1000).toFixed(1)}K` : '0';
-            next[2] = { ...next[2], value: totalK, sub: `${data.callCount || 0}回のAPI呼出` };
+            next[2] = { ...next[2], value: totalK, sub: `${data.callCount || 0}回のAPI呼出（本日累計）` };
+          }
+          if (scheduleRes.status === 'fulfilled') {
+            const sched = scheduleRes.value;
+            const total = sched.times?.length || 0;
+            const posted = sched.postedCount || 0;
+            next[1] = { ...next[1], value: `${posted}/${total}`, sub: `スケジュール (${sched.date || '---'})` };
           }
           return next;
         });


### PR DESCRIPTION
本日の投稿:
- /api/twitter/schedule API 追加: saves/auto_post_daily_schedule.json を読み込み
- KPICards が投稿済み/全件数を表示（例: 3/10）

トークン消費:
- /api/tokens/today API 追加: MongoDB の日次集計を返す（バックエンド再起動でも累計維持）
- KPICards が本日の累計トークン消費を表示（セッション単位ではなく日次累計）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new unauthenticated API endpoints and file system reads plus changes KPI data sources; risk is mainly incorrect/slow stats or missing-file handling affecting the dashboard.
> 
> **Overview**
> Updates the KPI dashboard to display *today’s cumulative* LLM token usage and API call count by switching the frontend from `/api/tokens/session` to a new `/api/tokens/today` endpoint that aggregates the last day from MongoDB-backed daily stats.
> 
> Adds a new `/api/twitter/schedule` endpoint that reads `saves/auto_post_daily_schedule.json`, and updates the “本日の投稿” KPI card to show `posted/total` along with the schedule date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b48480d5770dd6d10285501661bb536496fdb238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->