### PR TITLE
langfuse対応

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,8 @@
     "googleapis": "^126.0.1",
     "jimp": "^1.6.0",
     "langchain": "^0.3.13",
+    "langfuse": "^3.38.6",
+    "langfuse-langchain": "^3.38.6",
     "minecraft-protocol-forge": "^1.0.0",
     "minecrafthawkeye": "^1.3.6",
     "mineflayer": "^4.35.0",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -147,6 +147,12 @@ export const config = {
     apiKey: optional('GROQ_API_KEY', ''),
   },
 
+  langfuse: {
+    secretKey: optional('LANGFUSE_SECRET_KEY', ''),
+    publicKey: optional('LANGFUSE_PUBLIC_KEY', ''),
+    baseUrl: optional('LANGFUSE_BASE_URL', 'https://cloud.langfuse.com'),
+  },
+
   voicepeak: {
     serverUrl: optional('VOICEPEAK_SERVER_URL', 'http://localhost:8090'),
     narrator: optional('VOICEPEAK_NARRATOR', 'Japanese Female4'),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import http from 'http';
+import fs from 'fs';
 import path from 'path';
 import mongoose from 'mongoose';
 import { TwitterReplyOutput } from '@shannon/common';
@@ -17,6 +18,7 @@ import { WebClient } from './services/web/client.js';
 import { YoutubeClient } from './services/youtube/client.js';
 import { logger, initFileLogging } from './utils/logger.js';
 import { safeAsync } from './utils/safeAsync.js';
+import { shutdownLangfuse } from './services/llm/utils/langfuse.js';
 import { modelManager } from './config/modelManager.js';
 import { tokenTracker } from './services/llm/utils/tokenTracker.js';
 
@@ -133,8 +135,7 @@ class Server {
     // -----------------------------------------------------------------
     app.get('/api/twitter/schedule', (_req, res) => {
       try {
-        const fs = require('fs');
-        const schedulePath = require('path').resolve('saves/auto_post_daily_schedule.json');
+        const schedulePath = path.resolve('saves/auto_post_daily_schedule.json');
         if (fs.existsSync(schedulePath)) {
           const data = JSON.parse(fs.readFileSync(schedulePath, 'utf-8'));
           res.json(data);
@@ -787,6 +788,7 @@ class Server {
     // ルールは常時有効のままにしておく。
 
     // 各サービスのクリーンアップ処理
+    await shutdownLangfuse();
     await mongoose.disconnect();
     logger.error('MongoDB disconnected');
     process.exit(0);

--- a/backend/src/services/discord/voiceFiller.ts
+++ b/backend/src/services/discord/voiceFiller.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import OpenAI from 'openai';
 import { config } from '../../config/env.js';
+import { getTracedOpenAI } from '../llm/utils/langfuse.js';
 import { VoicepeakClient, VoicepeakEmotion } from '../voicepeak/client.js';
 import { logger } from '../../utils/logger.js';
 
@@ -410,7 +411,7 @@ export async function selectFiller(
   userName: string,
   conversationContext?: string,
 ): Promise<FillerSelection> {
-  const openai = new OpenAI({ apiKey: config.openaiApiKey });
+  const openai = getTracedOpenAI(new OpenAI({ apiKey: config.openaiApiKey }));
   const selectionList = buildSelectionList();
 
   const contextBlock = conversationContext

--- a/backend/src/services/llm/agents/autoTweetAgent.ts
+++ b/backend/src/services/llm/agents/autoTweetAgent.ts
@@ -1,5 +1,5 @@
 import { TwitterTrendData, AutoTweetMode } from '@shannon/common';
-import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../utils/langfuse.js';
 import {
   AIMessage,
   BaseMessage,
@@ -324,7 +324,7 @@ class AnalyzeTweetImageTool extends StructuredTool {
       if (!tweet) return 'ツイートが見つかりません';
       const imageUrls = extractMediaUrls(tweet);
       if (imageUrls.length === 0) return 'このツイートには画像がありません';
-      const model = new ChatOpenAI({ modelName: 'gpt-4o', temperature: 0 });
+      const model = createTracedModel({ modelName: 'gpt-4o', temperature: 0 });
       const result = await model.invoke([
         new HumanMessage({
           content: [
@@ -500,7 +500,7 @@ export class AutoTweetAgent {
     recentQuoteUrls?: string[],
     recentTopics?: string[],
   ): Promise<ExplorationResult | null> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweetExplore,
       temperature: 0.7,
     });
@@ -710,7 +710,7 @@ export class AutoTweetAgent {
   ): Promise<AutoTweetOutput | null> {
     const isGemini = models.autoTweetGenerate.startsWith('gemini');
     const isO1Style = models.autoTweetGenerate.startsWith('gpt-5') || models.autoTweetGenerate.startsWith('o');
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweetGenerate,
       ...(isO1Style ? {} : { temperature: 0.9 }),
       ...(isGemini
@@ -795,7 +795,7 @@ export class AutoTweetAgent {
   // =========================================================================
 
   private async review(draft: AutoTweetOutput): Promise<ReviewResult> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweetReview,
       temperature: 0,
     });

--- a/backend/src/services/llm/agents/memberTweetAgent.ts
+++ b/backend/src/services/llm/agents/memberTweetAgent.ts
@@ -6,11 +6,11 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import { StructuredTool } from '@langchain/core/tools';
-import { ChatOpenAI } from '@langchain/openai';
 import { TaskContext } from '@shannon/common';
 import { z } from 'zod';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import { IExchange } from '../../../models/PersonMemory.js';
 import { logger } from '../../../utils/logger.js';
 import { loadPrompt } from '../config/prompts.js';
@@ -150,7 +150,7 @@ export class MemberTweetAgent {
     }
 
     // === LLM呼び出し (FCA) ===
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.contentGeneration,
       temperature: 1,
     });

--- a/backend/src/services/llm/agents/postAboutTodayAgent.ts
+++ b/backend/src/services/llm/agents/postAboutTodayAgent.ts
@@ -1,6 +1,5 @@
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
-import { ChatOpenAI } from '@langchain/openai';
 import {
   AIMessage,
   BaseMessage,
@@ -12,6 +11,7 @@ import { StructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { models } from '../../../config/models.js';
 import { loadPrompt } from '../config/prompts.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import GoogleSearchTool from '../tools/googleSearch.js';
 import SearchByWikipediaTool from '../tools/searchByWikipedia.js';
 import { logger } from '../../../utils/logger.js';
@@ -160,7 +160,7 @@ export class PostAboutTodayAgent {
     today: string,
     feedback?: string,
   ): Promise<AboutTodayOutput | null> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 0.8,
     });
@@ -280,7 +280,7 @@ export class PostAboutTodayAgent {
   // =========================================================================
 
   private async review(draft: string): Promise<ReviewResult> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 0,
     });

--- a/backend/src/services/llm/agents/postFortuneAgent.ts
+++ b/backend/src/services/llm/agents/postFortuneAgent.ts
@@ -5,6 +5,7 @@ import { loadPrompt } from '../config/prompts.js';
 import { models } from '../../../config/models.js';
 import { logger } from '../../../utils/logger.js';
 import { createLLMWithFallback } from '../utils/llmWithFallback.js';
+import { createTracedModel } from '../utils/langfuse.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -204,7 +205,7 @@ export class PostFortuneAgent {
   // =========================================================================
 
   private async review(draft: string): Promise<ReviewResult> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 0,
     });

--- a/backend/src/services/llm/agents/postNewsAgent.ts
+++ b/backend/src/services/llm/agents/postNewsAgent.ts
@@ -1,6 +1,5 @@
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
-import { ChatOpenAI } from '@langchain/openai';
 import {
   AIMessage,
   BaseMessage,
@@ -12,6 +11,7 @@ import { StructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { models } from '../../../config/models.js';
 import { loadPrompt } from '../config/prompts.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import GoogleSearchTool from '../tools/googleSearch.js';
 import SearchByWikipediaTool from '../tools/searchByWikipedia.js';
 import { logger } from '../../../utils/logger.js';
@@ -155,7 +155,7 @@ export class PostNewsAgent {
     today: string,
     feedback?: string,
   ): Promise<NewsOutput | null> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 0.7,
     });
@@ -272,7 +272,7 @@ export class PostNewsAgent {
   // =========================================================================
 
   private async review(draft: string): Promise<ReviewResult> {
-    const model = new ChatOpenAI({
+    const model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 0,
     });

--- a/backend/src/services/llm/agents/postWeatherAgent.ts
+++ b/backend/src/services/llm/agents/postWeatherAgent.ts
@@ -1,5 +1,6 @@
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../utils/langfuse.js';
 import { PromptType } from '@shannon/common';
 import axios from 'axios';
 import { addDays, format } from 'date-fns';
@@ -111,7 +112,7 @@ export class PostWeatherAgent {
     systemPrompts: Map<PromptType, string>,
     cities: string[] = ['仙台', '東京', '名古屋', '大阪', '福岡']
   ) {
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.scheduledPost,
       apiKey: OPENAI_API_KEY,
     });

--- a/backend/src/services/llm/agents/quoteTwitterComment.ts
+++ b/backend/src/services/llm/agents/quoteTwitterComment.ts
@@ -2,6 +2,7 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { createTracedModel } from '../utils/langfuse.js';
 
 const OPENAI_API_KEY = config.openaiApiKey;
 if (!OPENAI_API_KEY) {
@@ -30,7 +31,7 @@ export class QuoteTwitterCommentAgent {
 - 自然で人間らしい文章にする`;
 
   private constructor() {
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       temperature: 1,
       apiKey: OPENAI_API_KEY,

--- a/backend/src/services/llm/agents/replyTwitterComment.ts
+++ b/backend/src/services/llm/agents/replyTwitterComment.ts
@@ -4,6 +4,7 @@ import { TaskContext } from '@shannon/common';
 import { loadPrompt } from '../config/prompts.js';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import { MemoryNode } from '../graph/nodes/MemoryNode.js';
 import { IExchange } from '../../../models/PersonMemory.js';
 import { logger } from '../../../utils/logger.js';
@@ -19,7 +20,7 @@ export class ReplyTwitterCommentAgent {
   private memoryNode: MemoryNode | null = null;
 
   private constructor(systemPrompt: string) {
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       temperature: 1,
       apiKey: OPENAI_API_KEY,

--- a/backend/src/services/llm/agents/replyYoutubeComment.ts
+++ b/backend/src/services/llm/agents/replyYoutubeComment.ts
@@ -4,6 +4,7 @@ import { TaskContext } from '@shannon/common';
 import { loadPrompt } from '../config/prompts.js';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import { MemoryNode } from '../graph/nodes/MemoryNode.js';
 import { IExchange } from '../../../models/PersonMemory.js';
 import { logger } from '../../../utils/logger.js';
@@ -19,7 +20,7 @@ export class ReplyYoutubeCommentAgent {
   private memoryNode: MemoryNode | null = null;
 
   private constructor(systemPrompt: string) {
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       temperature: 1,
       apiKey: OPENAI_API_KEY,

--- a/backend/src/services/llm/agents/replyYoutubeLiveCommentAgent.ts
+++ b/backend/src/services/llm/agents/replyYoutubeLiveCommentAgent.ts
@@ -4,6 +4,7 @@ import { TaskContext } from '@shannon/common';
 import { loadPrompt } from '../config/prompts.js';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { createTracedModel } from '../utils/langfuse.js';
 import { MemoryNode } from '../graph/nodes/MemoryNode.js';
 import { IExchange } from '../../../models/PersonMemory.js';
 import { logger } from '../../../utils/logger.js';
@@ -19,7 +20,7 @@ export class ReplyYoutubeLiveCommentAgent {
   private memoryNode: MemoryNode | null = null;
 
   private constructor(systemPrompt: string) {
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       temperature: 1,
       apiKey: OPENAI_API_KEY,

--- a/backend/src/services/llm/client.ts
+++ b/backend/src/services/llm/client.ts
@@ -55,6 +55,7 @@ import { ReplyTwitterCommentAgent } from './agents/replyTwitterComment.js';
 import { ReplyYoutubeCommentAgent } from './agents/replyYoutubeComment.js';
 import { ReplyYoutubeLiveCommentAgent } from './agents/replyYoutubeLiveCommentAgent.js';
 import { TaskGraph } from './graph/taskGraph.js';
+import { getTracedOpenAI } from './utils/langfuse.js';
 import { logger } from '../../utils/logger.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -103,11 +104,11 @@ export class LLMService {
     this.realtimeApi = RealtimeAPIService.getInstance();
     this.taskGraph = TaskGraph.getInstance();
     this.voicepeakClient = VoicepeakClient.getInstance();
-    this.openaiClient = new OpenAI({ apiKey: config.openaiApiKey });
-    this.groqClient = new OpenAI({
+    this.openaiClient = getTracedOpenAI(new OpenAI({ apiKey: config.openaiApiKey }));
+    this.groqClient = getTracedOpenAI(new OpenAI({
       apiKey: config.groq.apiKey || config.openaiApiKey,
       baseURL: config.groq.apiKey ? 'https://api.groq.com/openai/v1' : undefined,
-    });
+    }));
     this.setupEventBus();
     this.setupRealtimeAPICallback();
   }

--- a/backend/src/services/llm/graph/nodes/EmotionNode.ts
+++ b/backend/src/services/llm/graph/nodes/EmotionNode.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../utils/langfuse.js';
 import { config } from '../../../../config/env.js';
 import { models } from '../../../../config/models.js';
 import { AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
@@ -100,7 +101,7 @@ export class EmotionNode {
 
         // gpt-5-mini（感情分析は軽量モデルで十分）
         // gpt-5-mini は temperature=1 のみサポート（デフォルト値を使用）
-        this.model = new ChatOpenAI({
+        this.model = createTracedModel({
             modelName: models.emotion,
             apiKey: config.openaiApiKey,
         });

--- a/backend/src/services/llm/graph/nodes/FunctionCallingAgent.ts
+++ b/backend/src/services/llm/graph/nodes/FunctionCallingAgent.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../utils/langfuse.js';
 import { tokenTracker } from '../../utils/tokenTracker.js';
 import { config } from '../../../../config/env.js';
 import { models } from '../../../../config/models.js';
@@ -96,7 +97,7 @@ export class FunctionCallingAgent {
             this.updatePlanTool = planTool;
         }
 
-        this.model = new ChatOpenAI({
+        this.model = createTracedModel({
             modelName: FunctionCallingAgent.MODEL_NAME,
             apiKey: config.openaiApiKey,
             temperature: 0,

--- a/backend/src/services/llm/graph/nodes/MemoryNode.ts
+++ b/backend/src/services/llm/graph/nodes/MemoryNode.ts
@@ -2,6 +2,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { config } from '../../../../config/env.js';
 import { models } from '../../../../config/models.js';
+import { createTracedModel } from '../../utils/langfuse.js';
 import { TaskContext } from '@shannon/common';
 import { IPersonMemory, MemoryPlatform } from '../../../../models/PersonMemory.js';
 import { IShannonMemory } from '../../../../models/ShannonMemory.js';
@@ -116,7 +117,7 @@ export class MemoryNode {
     this.personService = PersonMemoryService.getInstance();
     this.shannonService = ShannonMemoryService.getInstance();
     // gpt-5-mini は temperature=1 のみサポート（デフォルト値を使用）
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       apiKey: config.openaiApiKey,
     });

--- a/backend/src/services/llm/tools/createImage.ts
+++ b/backend/src/services/llm/tools/createImage.ts
@@ -6,6 +6,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { getTracedOpenAI } from '../utils/langfuse.js';
 import { logger } from '../../../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,7 +30,7 @@ export default class CreateImageTool extends StructuredTool {
     if (!openaiApiKey) {
       throw new Error('OPENAI_API_KEY environment variable is not set.');
     }
-    this.openai = new OpenAI({ apiKey: openaiApiKey });
+    this.openai = getTracedOpenAI(new OpenAI({ apiKey: openaiApiKey }));
 
     // 画像保存ディレクトリ
     this.outputDir = join(__dirname, '../../../../saves/images/generated');

--- a/backend/src/services/llm/tools/describeImage.ts
+++ b/backend/src/services/llm/tools/describeImage.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { z } from 'zod';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { getTracedOpenAI } from '../utils/langfuse.js';
 import { logger } from '../../../utils/logger.js';
 
 export default class DescribeImageTool extends StructuredTool {
@@ -23,7 +24,7 @@ export default class DescribeImageTool extends StructuredTool {
     if (!openaiApiKey) {
       throw new Error('OPENAI_API_KEY environment variable is not set.');
     }
-    this.openai = new OpenAI({ apiKey: openaiApiKey });
+    this.openai = getTracedOpenAI(new OpenAI({ apiKey: openaiApiKey }));
   }
 
   async _call(data: z.infer<typeof this.schema>): Promise<string> {

--- a/backend/src/services/llm/tools/describeNotionImage.ts
+++ b/backend/src/services/llm/tools/describeNotionImage.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 import { z } from 'zod';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { getTracedOpenAI } from '../utils/langfuse.js';
 import { logger } from '../../../utils/logger.js';
 
 // 画像URLキャッシュ（グローバル）
@@ -50,7 +51,7 @@ export default class DescribeNotionImageTool extends StructuredTool {
         if (!openaiApiKey) {
             throw new Error('OPENAI_API_KEY environment variable is not set.');
         }
-        this.openai = new OpenAI({ apiKey: openaiApiKey });
+        this.openai = getTracedOpenAI(new OpenAI({ apiKey: openaiApiKey }));
     }
 
     async _call(data: z.infer<typeof this.schema>): Promise<string> {

--- a/backend/src/services/llm/tools/generateTweetText.ts
+++ b/backend/src/services/llm/tools/generateTweetText.ts
@@ -1,5 +1,6 @@
 import { StructuredTool } from '@langchain/core/tools';
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../utils/langfuse.js';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
 import { config } from '../../../config/env.js';
@@ -34,7 +35,7 @@ export default class GenerateTweetTextTool extends StructuredTool {
 
   constructor() {
     super();
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.autoTweet,
       temperature: 1,
     });
@@ -89,7 +90,7 @@ export async function generateTweetForAutoPost(
   topic: string,
   systemPrompt?: string
 ): Promise<string> {
-  const model = new ChatOpenAI({
+  const model = createTracedModel({
     modelName: models.autoTweet,
     temperature: 1,
   });

--- a/backend/src/services/llm/utils/generateImage.ts
+++ b/backend/src/services/llm/utils/generateImage.ts
@@ -1,9 +1,10 @@
 import OpenAI from 'openai';
 import { config } from '../../../config/env.js';
 import { models } from '../../../config/models.js';
+import { getTracedOpenAI } from './langfuse.js';
 import { logger } from '../../../utils/logger.js';
 
-const openai = new OpenAI({ apiKey: config.openaiApiKey });
+const openai = getTracedOpenAI(new OpenAI({ apiKey: config.openaiApiKey }));
 
 /**
  * OpenAI gpt-image でテキストから画像を生成し、Buffer を返す。

--- a/backend/src/services/llm/utils/langfuse.ts
+++ b/backend/src/services/llm/utils/langfuse.ts
@@ -1,0 +1,95 @@
+/**
+ * Langfuse integration for LLM observability.
+ *
+ * Provides:
+ *  - createTracedModel()   — drop-in replacement for `new ChatOpenAI()`
+ *  - getTracedOpenAI()     — wrapped OpenAI client for direct API calls
+ *  - langfuseEnabled       — whether Langfuse credentials are configured
+ *  - shutdownLangfuse()    — flush pending events (call on graceful shutdown)
+ */
+import { ChatOpenAI, type ChatOpenAICallOptions } from '@langchain/openai';
+import OpenAI from 'openai';
+import { config } from '../../../config/env.js';
+import { logger } from '../../../utils/logger.js';
+
+type ChatOpenAIConstructorArgs = ConstructorParameters<typeof ChatOpenAI>[0];
+
+let _langfuse: any = null;
+let _callbackHandler: any = null;
+let _initAttempted = false;
+
+export const langfuseEnabled =
+  !!config.langfuse.secretKey && !!config.langfuse.publicKey;
+
+async function initLangfuse() {
+  if (_initAttempted) return;
+  _initAttempted = true;
+
+  if (!langfuseEnabled) {
+    logger.debug('[Langfuse] No credentials configured — tracing disabled');
+    return;
+  }
+
+  try {
+    const { Langfuse } = await import('langfuse');
+    _langfuse = new Langfuse({
+      secretKey: config.langfuse.secretKey,
+      publicKey: config.langfuse.publicKey,
+      baseUrl: config.langfuse.baseUrl,
+    });
+    logger.info('[Langfuse] Initialized — tracing enabled');
+
+    const { CallbackHandler } = await import('langfuse-langchain');
+    _callbackHandler = new CallbackHandler({
+      secretKey: config.langfuse.secretKey,
+      publicKey: config.langfuse.publicKey,
+      baseUrl: config.langfuse.baseUrl,
+    });
+  } catch (err) {
+    logger.warn(`[Langfuse] Failed to initialize: ${err}`);
+  }
+}
+
+const _initPromise = initLangfuse();
+
+/**
+ * Drop-in replacement for `new ChatOpenAI(...)`.
+ * Automatically attaches the Langfuse callback handler when credentials are set.
+ */
+export function createTracedModel(
+  opts?: ChatOpenAIConstructorArgs,
+): ChatOpenAI {
+  if (!_callbackHandler) {
+    return new ChatOpenAI(opts);
+  }
+  const existing = (opts as any)?.callbacks ?? [];
+  return new ChatOpenAI({
+    ...opts,
+    callbacks: [...existing, _callbackHandler],
+  } as any);
+}
+
+/**
+ * Wraps an OpenAI client instance with Langfuse observation (for direct API calls).
+ */
+export function getTracedOpenAI(client: OpenAI): OpenAI {
+  if (!_langfuse) return client;
+  try {
+    return _langfuse.observeOpenAI(client) as OpenAI;
+  } catch {
+    return client;
+  }
+}
+
+/**
+ * Flush pending Langfuse events. Call on graceful shutdown.
+ */
+export async function shutdownLangfuse(): Promise<void> {
+  await _initPromise;
+  if (_callbackHandler) {
+    try { await _callbackHandler.flushAsync(); } catch { /* noop */ }
+  }
+  if (_langfuse) {
+    try { await _langfuse.shutdownAsync(); } catch { /* noop */ }
+  }
+}

--- a/backend/src/services/llm/utils/llmWithFallback.ts
+++ b/backend/src/services/llm/utils/llmWithFallback.ts
@@ -3,6 +3,7 @@
  * プライマリが失敗した場合にフォールバックプロバイダーへ自動切替する。
  */
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from './langfuse.js';
 import { config } from '../../../config/env.js';
 import { logger } from '../../../utils/logger.js';
 
@@ -15,7 +16,7 @@ interface FallbackConfig {
 }
 
 export function createLLMWithFallback(cfg: FallbackConfig): ChatOpenAI {
-  const primary = new ChatOpenAI({
+  const primary = createTracedModel({
     modelName: cfg.primaryModel,
     openAIApiKey: config.openaiApiKey,
     maxRetries: cfg.maxRetries ?? 2,
@@ -26,7 +27,7 @@ export function createLLMWithFallback(cfg: FallbackConfig): ChatOpenAI {
   const fallbackApiKey = cfg.fallbackApiKey || config.groq.apiKey || config.google.geminiApiKey;
   if (!fallbackApiKey) return primary;
 
-  const fallback = new ChatOpenAI({
+  const fallback = createTracedModel({
     modelName: cfg.fallbackModel,
     openAIApiKey: fallbackApiKey,
     configuration: cfg.fallbackBaseURL ? { baseURL: cfg.fallbackBaseURL } : undefined,

--- a/backend/src/services/memory/personMemoryService.ts
+++ b/backend/src/services/memory/personMemoryService.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../llm/utils/langfuse.js';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import {
   PersonMemory,
@@ -46,7 +47,7 @@ export class PersonMemoryService {
 
   private constructor() {
     // gpt-5-mini は temperature=1 のみサポート（デフォルト値を使用）
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName: models.contentGeneration,
       apiKey: config.openaiApiKey,
     });

--- a/backend/src/services/minebot/eventReaction/EmergencyResponder.ts
+++ b/backend/src/services/minebot/eventReaction/EmergencyResponder.ts
@@ -6,6 +6,7 @@
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../llm/utils/langfuse.js';
 import { CustomBot } from '../types.js';
 import { models } from '../../../config/models.js';
 import {
@@ -31,10 +32,10 @@ export class EmergencyResponder {
 
     constructor(bot: CustomBot) {
         this.bot = bot;
-        this.llm = new ChatOpenAI({
+        this.llm = createTracedModel({
             modelName: models.emergency,
-            temperature: 0.1, // 低い温度で一貫した応答
-            maxTokens: 150,   // 短い応答で高速化
+            temperature: 0.1,
+            maxTokens: 150,
         });
     }
 

--- a/backend/src/services/minebot/instantSkills/investigateTerrain.ts
+++ b/backend/src/services/minebot/instantSkills/investigateTerrain.ts
@@ -4,6 +4,7 @@ import {
   ToolMessage,
 } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../llm/utils/langfuse.js';
 import { CONFIG } from '../config/MinebotConfig.js';
 import { CustomBot, InstantSkill } from '../types.js';
 import { createLogger } from '../../../utils/logger.js';
@@ -40,7 +41,7 @@ class InvestigateTerrain extends InstantSkill {
   constructor(bot: CustomBot) {
     super(bot);
     // LLMインスタンスを作成
-    this.llm = new ChatOpenAI({
+    this.llm = createTracedModel({
       modelName: CONFIG.EXECUTION_MODEL,
       temperature: 0.1,
       apiKey: CONFIG.OPENAI_API_KEY,

--- a/backend/src/services/minebot/llm/agents/ActionJudge.ts
+++ b/backend/src/services/minebot/llm/agents/ActionJudge.ts
@@ -6,6 +6,7 @@
 
 import { BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../../llm/utils/langfuse.js';
 import { z } from 'zod';
 import { createLogger } from '../../../../utils/logger.js';
 import { CONFIG } from '../../config/MinebotConfig.js';
@@ -34,7 +35,7 @@ export class ActionJudge implements IActionJudge {
     private openai: ChatOpenAI;
 
     constructor() {
-        this.openai = new ChatOpenAI({
+        this.openai = createTracedModel({
             modelName: CONFIG.CENTRAL_AGENT_MODEL,
             apiKey: CONFIG.OPENAI_API_KEY,
             temperature: CONFIG.TEMPERATURE_CENTRAL,

--- a/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
+++ b/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../../../llm/utils/langfuse.js';
 import {
   AIMessage,
   BaseMessage,
@@ -106,7 +107,7 @@ export class FunctionCallingAgent {
 
     const modelName = FunctionCallingAgent.MODEL_NAME;
 
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName,
       apiKey: config.openaiApiKey,
       temperature: 0,

--- a/backend/src/services/minebot/llm/graph/nodes/PlanningNode.ts
+++ b/backend/src/services/minebot/llm/graph/nodes/PlanningNode.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { createTracedModel } from '../../../../llm/utils/langfuse.js';
 import { HierarchicalSubTask, TaskTreeState } from '@shannon/common';
 import { Vec3 } from 'vec3';
 import { z } from 'zod';
@@ -69,7 +70,7 @@ export class PlanningNode {
     const modelName = models.planning;
     const reasoningEffort = 'low';
 
-    this.model = new ChatOpenAI({
+    this.model = createTracedModel({
       modelName,
       apiKey: config.openaiApiKey,
       timeout: 45000, // 45秒タイムアウト

--- a/backend/src/services/minebot/llm/tools/createBluePrint.ts
+++ b/backend/src/services/minebot/llm/tools/createBluePrint.ts
@@ -3,6 +3,7 @@ import { config } from '../../../../config/env.js';
 import { models } from '../../../../config/models.js';
 import fs from 'fs';
 import OpenAI from 'openai';
+import { getTracedOpenAI } from '../../../llm/utils/langfuse.js';
 import path from 'path';
 import { z } from 'zod';
 
@@ -34,7 +35,7 @@ export default class CreateBluePrintTool extends StructuredTool {
 
   constructor() {
     super();
-    this.openai = new OpenAI({ apiKey: config.openaiApiKey });
+    this.openai = getTracedOpenAI(new OpenAI({ apiKey: config.openaiApiKey }));
   }
 
   async _call(data: z.infer<typeof this.schema>): Promise<string> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad cross-cutting change to LLM client construction and runtime initialization/shutdown; misconfiguration or callback wrapping issues could affect LLM request behavior or shutdown timing, though tracing is gated behind optional credentials.
> 
> **Overview**
> Adds Langfuse observability across the backend’s LLM stack by introducing `services/llm/utils/langfuse.ts` and wiring LangChain `ChatOpenAI` and raw `OpenAI` clients through `createTracedModel`/`getTracedOpenAI` when `LANGFUSE_*` env vars are set.
> 
> Updates many agents/tools (tweet generation/replies, memory/emotion nodes, minebot skills, image generation, Discord voice filler) to use the traced wrappers, and ensures traces flush on graceful shutdown via `shutdownLangfuse()`.
> 
> Also adds `langfuse`/`langfuse-langchain` deps, new `config.langfuse` env config, and a small `server.ts` cleanup to use imported `fs/path` instead of `require`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e132c361aa471dd1ae0732401bc847968a6d1fdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->