### PR TITLE
minebot音声入力

### DIFF
--- a/backend/src/services/discord/client.ts
+++ b/backend/src/services/discord/client.ts
@@ -157,6 +157,7 @@ export class DiscordBot extends BaseClient {
   }> = new Map();
   private voicePttMessages: Map<string, { channelId: string; messageId: string }> = new Map(); // guildId -> PTT message
   private voiceStreamMessages: Map<string, { message: Message; accumulatedText: string }> = new Map(); // guildId -> streaming Discord message
+  private voiceModeMap: Map<string, 'chat' | 'minebot'> = new Map(); // guildId -> voice mode
   public static getInstance(isDev?: boolean) {
     if (!DiscordBot.instance) {
       DiscordBot.instance = new DiscordBot('discord', isDev ?? false);
@@ -349,6 +350,19 @@ export class DiscordBot extends BaseClient {
         new SlashCommandBuilder()
           .setName('generate_fillers')
           .setDescription('フィラー音声を生成する（初回のみ必要）'),
+        new SlashCommandBuilder()
+          .setName('voice_mode')
+          .setDescription('音声モードを切り替える（chat / minebot）')
+          .addStringOption(option =>
+            option
+              .setName('mode')
+              .setDescription('音声モード')
+              .setRequired(true)
+              .addChoices(
+                { name: 'chat（通常会話）', value: 'chat' },
+                { name: 'minebot（Minecraft操作）', value: 'minebot' },
+              )
+          ),
       ];
 
       // コマンドをJSON形式に変換
@@ -649,6 +663,20 @@ export class DiscordBot extends BaseClient {
               await interaction.deferReply({ flags: 64 });
               const count = await generateAllFillers();
               await interaction.editReply(`フィラー音声を ${count} 個生成しました。`);
+            }
+            break;
+
+          case 'voice_mode':
+            if (interaction.isChatInputCommand()) {
+              const mode = interaction.options.getString('mode', true) as 'chat' | 'minebot';
+              const guildId = interaction.guildId;
+              if (!guildId) {
+                await interaction.reply({ content: 'サーバー内で使用してください。', ephemeral: true });
+                break;
+              }
+              this.voiceModeMap.set(guildId, mode);
+              const modeLabel = mode === 'minebot' ? 'Minebot（Minecraft操作）' : 'Chat（通常会話）';
+              await interaction.reply(`音声モードを **${modeLabel}** に切り替えました。`);
             }
             break;
         }
@@ -2054,5 +2082,19 @@ export class DiscordBot extends BaseClient {
       );
       return [];
     }
+  }
+
+  public getVoiceMode(guildId: string): 'chat' | 'minebot' {
+    return this.voiceModeMap.get(guildId) ?? 'chat';
+  }
+
+  public getActiveVoiceInfo(): { guildId: string; channelId: string } | null {
+    for (const [guildId, connection] of this.voiceConnections.entries()) {
+      if (connection.state.status === VoiceConnectionStatus.Ready) {
+        const channelId = connection.joinConfig.channelId;
+        if (channelId) return { guildId, channelId };
+      }
+    }
+    return null;
   }
 }

--- a/backend/src/services/llm/agents/postFortuneAgent.ts
+++ b/backend/src/services/llm/agents/postFortuneAgent.ts
@@ -3,8 +3,8 @@ import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { z } from 'zod';
 import { loadPrompt } from '../config/prompts.js';
 import { models } from '../../../config/models.js';
+import { config } from '../../../config/env.js';
 import { logger } from '../../../utils/logger.js';
-import { createLLMWithFallback } from '../utils/llmWithFallback.js';
 import { createTracedModel } from '../utils/langfuse.js';
 
 // ---------------------------------------------------------------------------
@@ -107,10 +107,26 @@ export class PostFortuneAgent {
       '挑戦', '伝統', '友情', '直感',
       '競争', '忠実', '知性', '夢',
     ];
-    this.model = createLLMWithFallback({
-      primaryModel: models.contentGeneration,
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
+    this.model = createTracedModel({
+      modelName: models.contentGeneration,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 8192 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1, maxTokens: 8192 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: config.openaiApiKey }),
     });
-    this.model.maxTokens = 8192;
   }
 
   public static async create(): Promise<PostFortuneAgent> {

--- a/backend/src/services/llm/agents/quoteTwitterComment.ts
+++ b/backend/src/services/llm/agents/quoteTwitterComment.ts
@@ -31,10 +31,25 @@ export class QuoteTwitterCommentAgent {
 - 自然で人間らしい文章にする`;
 
   private constructor() {
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
     this.model = createTracedModel({
       modelName: models.contentGeneration,
-      temperature: 1,
-      apiKey: OPENAI_API_KEY,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 4096 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: OPENAI_API_KEY }),
     });
   }
 

--- a/backend/src/services/llm/agents/replyYoutubeComment.ts
+++ b/backend/src/services/llm/agents/replyYoutubeComment.ts
@@ -20,10 +20,25 @@ export class ReplyYoutubeCommentAgent {
   private memoryNode: MemoryNode | null = null;
 
   private constructor(systemPrompt: string) {
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
     this.model = createTracedModel({
       modelName: models.contentGeneration,
-      temperature: 1,
-      apiKey: OPENAI_API_KEY,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 4096 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: OPENAI_API_KEY }),
     });
     this.systemPrompt = systemPrompt;
   }

--- a/backend/src/services/llm/agents/replyYoutubeLiveCommentAgent.ts
+++ b/backend/src/services/llm/agents/replyYoutubeLiveCommentAgent.ts
@@ -20,10 +20,25 @@ export class ReplyYoutubeLiveCommentAgent {
   private memoryNode: MemoryNode | null = null;
 
   private constructor(systemPrompt: string) {
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
     this.model = createTracedModel({
       modelName: models.contentGeneration,
-      temperature: 1,
-      apiKey: OPENAI_API_KEY,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 4096 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: OPENAI_API_KEY }),
     });
     this.systemPrompt = systemPrompt;
   }

--- a/backend/src/services/llm/client.ts
+++ b/backend/src/services/llm/client.ts
@@ -13,6 +13,7 @@ import {
   EmotionType,
   MemberTweetInput,
   MemoryZone,
+  MinebotVoiceResponseOutput,
   OpenAICommandInput,
   OpenAIMessageOutput,
   OpenAIRealTimeAudioInput,
@@ -197,6 +198,12 @@ export class LLMService {
 
     this.eventBus.subscribe('llm:get_youtube_message', (event) => {
       this.processYoutubeMessage(event.data as YoutubeLiveChatMessageOutput);
+    });
+
+    this.eventBus.subscribe('minebot:voice_response', (event) => {
+      this.processMinebotVoiceResponse(event.data as MinebotVoiceResponseOutput).catch((err) => {
+        logger.error('[Minebot Voice] 未処理エラー:', err);
+      });
     });
   }
 
@@ -590,6 +597,15 @@ export class LLMService {
     });
   }
 
+  private async getVoiceMode(guildId: string): Promise<'chat' | 'minebot'> {
+    try {
+      const { DiscordBot } = await import('../discord/client.js');
+      return DiscordBot.getInstance().getVoiceMode(guildId);
+    } catch {
+      return 'chat';
+    }
+  }
+
   private async processDiscordVoiceMessage(message: DiscordVoiceMessageOutput) {
     const memoryZone = await getDiscordMemoryZone(message.guildId);
     const voiceMsg = message as any;
@@ -780,6 +796,24 @@ export class LLMService {
       }
     }
 
+    // 3c. Minebot mode: delegate to Minebot FCA instead of Shannon LLM
+    const voiceMode = await this.getVoiceMode(message.guildId);
+    if (voiceMode === 'minebot') {
+      logger.info(`[Voice] Minebot mode — routing to minebot:voice_chat`, 'magenta');
+      this.publishVoiceStatus(memoryZone, message.guildId, 'llm', '🤖 Minebot処理中...');
+      this.eventBus.publish({
+        type: 'minebot:voice_chat',
+        memoryZone: 'minebot',
+        data: {
+          userName: message.userName,
+          message: transcribedText,
+          guildId: message.guildId,
+          channelId: message.channelId,
+        },
+      });
+      return;
+    }
+
     // 4. Run LLM in parallel (fillers are already playing)
     this.publishVoiceStatus(memoryZone, message.guildId, 'llm');
     const llmStartTime = Date.now();
@@ -942,6 +976,46 @@ export class LLMService {
         text: responseText,
       } as DiscordVoiceQueueEndInput,
     });
+  }
+
+  private async processMinebotVoiceResponse(data: MinebotVoiceResponseOutput) {
+    const { guildId, channelId, responseText } = data;
+    if (!responseText) {
+      logger.warn('[Minebot Voice] Empty response text');
+      this.eventBus.publish({
+        type: 'discord:voice_queue_end',
+        memoryZone: 'minebot' as any,
+        data: { guildId, channelId, text: '' } as DiscordVoiceQueueEndInput,
+      });
+      return;
+    }
+
+    const memoryZone = (await getDiscordMemoryZone(guildId)) as any;
+    logger.info(`[Minebot Voice] TTS for response: "${responseText.substring(0, 60)}..."`, 'magenta');
+    this.publishVoiceStatus(memoryZone, guildId, 'tts', '🤖 Minebot TTS...');
+
+    try {
+      const sentences = splitIntoSentences(responseText);
+      for (const s of sentences) {
+        const wavBuf = await this.voicepeakClient.synthesize(s);
+        this.eventBus.publish({
+          type: 'discord:voice_enqueue',
+          memoryZone,
+          data: { guildId, audioBuffer: wavBuf } as DiscordVoiceEnqueueInput,
+        });
+      }
+    } catch (error) {
+      logger.error('[Minebot Voice] TTS failed:', error);
+    }
+
+    this.eventBus.publish({
+      type: 'discord:voice_queue_end',
+      memoryZone,
+      data: { guildId, channelId, text: responseText } as DiscordVoiceQueueEndInput,
+    });
+
+    voiceResponseChannelIds.delete(channelId);
+    logger.info(`[Minebot Voice] Response complete`, 'magenta');
   }
 
   private async processCreateScheduledPost(message: TwitterClientInput) {

--- a/backend/src/services/llm/graph/nodes/FunctionCallingAgent.ts
+++ b/backend/src/services/llm/graph/nodes/FunctionCallingAgent.ts
@@ -162,10 +162,11 @@ export class FunctionCallingAgent {
         );
 
         // Minecraft ボットの場合、ワールド知識を注入
-        if (state.environmentState?.botPosition) {
-            try {
+        try {
+            const envObj = state.environmentState ? JSON.parse(state.environmentState) : null;
+            if (envObj?.botPosition) {
                 const wk = WorldKnowledgeService.getInstance();
-                const pos = state.environmentState.botPosition;
+                const pos = envObj.botPosition;
                 const knowledgeContext = await wk.buildContextForPosition(
                     { x: Math.floor(pos.x), y: Math.floor(pos.y), z: Math.floor(pos.z) },
                     64,
@@ -173,8 +174,8 @@ export class FunctionCallingAgent {
                 if (knowledgeContext) {
                     systemPrompt += knowledgeContext;
                 }
-            } catch {}
-        }
+            }
+        } catch {}
 
         const messages: BaseMessage[] = [
             new SystemMessage(systemPrompt),

--- a/backend/src/services/llm/graph/nodes/MemoryNode.ts
+++ b/backend/src/services/llm/graph/nodes/MemoryNode.ts
@@ -116,10 +116,25 @@ export class MemoryNode {
   constructor() {
     this.personService = PersonMemoryService.getInstance();
     this.shannonService = ShannonMemoryService.getInstance();
-    // gpt-5-mini は temperature=1 のみサポート（デフォルト値を使用）
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
     this.model = createTracedModel({
       modelName: models.contentGeneration,
-      apiKey: config.openaiApiKey,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 4096 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: config.openaiApiKey }),
     });
   }
 

--- a/backend/src/services/memory/personMemoryService.ts
+++ b/backend/src/services/memory/personMemoryService.ts
@@ -46,10 +46,25 @@ export class PersonMemoryService {
   private extractTraitsPrompt: string | null = null;
 
   private constructor() {
-    // gpt-5-mini は temperature=1 のみサポート（デフォルト値を使用）
+    const isGemini = models.contentGeneration.startsWith('gemini');
+    const isReasoning = models.contentGeneration.startsWith('gpt-5') || models.contentGeneration.startsWith('o');
     this.model = createTracedModel({
       modelName: models.contentGeneration,
-      apiKey: config.openaiApiKey,
+      ...(isReasoning
+        ? { modelKwargs: { max_completion_tokens: 4096 } }
+        : isGemini
+          ? { maxTokens: 8192 }
+          : { temperature: 1 }),
+      ...(isGemini
+        ? {
+            timeout: 300000,
+            configuration: {
+              baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
+              apiKey: config.google.geminiApiKey,
+            },
+            apiKey: config.google.geminiApiKey,
+          }
+        : { apiKey: config.openaiApiKey }),
     });
   }
 

--- a/backend/src/services/minebot/config/MinebotConfig.ts
+++ b/backend/src/services/minebot/config/MinebotConfig.ts
@@ -149,6 +149,22 @@ export class MinebotConfig {
   /** チェックタイムアウト間隔（ミリ秒） - サーバーのKeep-Alive応答用 */
   readonly CHECK_TIMEOUT_INTERVAL = 30 * 1000; // 30秒（サーバーのデフォルトタイムアウトに合わせる）
 
+  // ===== Discord → Minecraft ユーザー名マッピング =====
+  // key: Discord の getUserNickname() で返される名前（小文字）
+  // value: Minecraft のプレイヤー名
+  readonly DISCORD_TO_MINECRAFT_NAMES: Record<string, string> = {
+    'ライ': 'Rai1241',
+    'ryo07010': 'Rai1241',
+    'ヤミー': 'yummy34',
+    'yummy3434': 'yummy34',
+    'グリコ': 'guriko8670',
+    '12357': 'guriko8670',
+  };
+
+  resolveMinecraftName(discordName: string): string {
+    return this.DISCORD_TO_MINECRAFT_NAMES[discordName] ?? discordName;
+  }
+
   // ===== 定期実行間隔 =====
 
   /** 100ms間隔タスク */

--- a/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
+++ b/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
@@ -65,6 +65,7 @@ export class FunctionCallingAgent {
   private centralLogManager: CentralLogManager;
   private onEmergencyResolved: (() => Promise<void>) | null = null;
   private updatePlanTool: UpdatePlanTool | null = null;
+  private onResponseText: ((text: string) => void) | null = null;
 
   // ユーザーからのリアルタイムフィードバック
   private pendingFeedback: string[] = [];
@@ -125,6 +126,10 @@ export class FunctionCallingAgent {
    */
   public setEmergencyResolvedHandler(handler: () => Promise<void>): void {
     this.onEmergencyResolved = handler;
+  }
+
+  public setOnResponseText(callback: ((text: string) => void) | null): void {
+    this.onResponseText = callback;
   }
 
   /**
@@ -381,6 +386,10 @@ export class FunctionCallingAgent {
               this.bot.chat(content.substring(0, 250));
             } catch (e) {
               log.warn(`⚠ チャット送信失敗: ${(e as Error).message}`);
+            }
+            if (this.onResponseText) {
+              try { this.onResponseText(content); } catch { /* best-effort */ }
+              this.onResponseText = null;
             }
           }
 

--- a/backend/src/services/minebot/llm/graph/taskGraph.ts
+++ b/backend/src/services/minebot/llm/graph/taskGraph.ts
@@ -116,6 +116,16 @@ export class TaskGraph {
   }
 
   /**
+   * 音声応答コールバックを設定（Minebot音声モード用）
+   * FCAがテキスト応答を生成した際にコールバックを発火する
+   */
+  public setOnResponseText(callback: ((text: string) => void) | null): void {
+    if (this.functionCallingAgent) {
+      this.functionCallingAgent.setOnResponseText(callback);
+    }
+  }
+
+  /**
    * Function Calling モードの切り替え
    */
   public setUseFunctionCalling(value: boolean): void {

--- a/backend/src/services/minebot/skillAgent.ts
+++ b/backend/src/services/minebot/skillAgent.ts
@@ -1,5 +1,5 @@
 import { AIMessage, BaseMessage, HumanMessage } from '@langchain/core/messages';
-import { MinebotSkillInput } from '@shannon/common';
+import { MinebotSkillInput, MinebotVoiceChatInput } from '@shannon/common';
 import fetch from 'node-fetch';
 import { Vec3 } from 'vec3';
 import { EventBus } from '../eventBus/eventBus.js';
@@ -420,6 +420,33 @@ export class SkillAgent {
    * EventBus購読を登録
    */
   private async registerEventBusSubscriptions() {
+    // Discord音声経由のMinebotチャット
+    this.eventBus.subscribe('minebot:voice_chat', async (event) => {
+      const { userName, message, guildId, channelId } = event.data as MinebotVoiceChatInput;
+      const mcName = CONFIG.resolveMinecraftName(userName);
+      log.info(`🎙️ Voice chat from ${userName} (MC: ${mcName}): ${message}`, 'cyan');
+
+      this.updateSenderInfo(mcName);
+
+      const taskGraph = this.centralAgent.currentTaskGraph;
+      if (taskGraph) {
+        taskGraph.setOnResponseText((responseText: string) => {
+          this.eventBus.publish({
+            type: 'minebot:voice_response',
+            memoryZone: 'minebot',
+            data: { guildId, channelId, responseText },
+          });
+        });
+      }
+
+      await this.processMessage(
+        mcName,
+        message,
+        JSON.stringify(this.bot.environmentState),
+        JSON.stringify(this.bot.selfState),
+      );
+    });
+
     // スキル読み込みイベント
     this.eventBus.subscribe('minebot:loadSkills', async (event) => {
       try {

--- a/common/dist/types/common.d.ts
+++ b/common/dist/types/common.d.ts
@@ -1,6 +1,6 @@
 import { DiscordClientInput, DiscordClientOutput, DiscordEventType, DiscordGuild, DiscordVoiceEnqueueInput, DiscordVoiceFillerInput, DiscordVoiceMessageOutput, DiscordVoiceQueueEndInput, DiscordVoiceQueueStartInput, DiscordVoiceResponseInput, DiscordVoiceStatusInput } from './discord.js';
 import { LLMEventType, SkillInfo } from './llm.js';
-import { MinebotEventType, MinebotInput, MinebotOutput, SkillParameters, SkillResult } from './minebot.js';
+import { MinebotEventType, MinebotInput, MinebotOutput, MinebotVoiceChatInput, MinebotVoiceResponseOutput, SkillParameters, SkillResult } from './minebot.js';
 import { MinecraftEventType, MinecraftInput, MinecraftOutput } from './minecraft.js';
 import { NotionClientInput, NotionClientOutput, NotionEventType } from './notion.js';
 import { SchedulerEventType, SchedulerInput, SchedulerOutput } from './scheduler.js';
@@ -77,7 +77,7 @@ export type EventType = TaskEventType | TwitterEventType | YoutubeEventType | Mi
 export interface Event {
     type: EventType;
     memoryZone: MemoryZone;
-    data: TwitterClientInput | TwitterClientOutput | OpenAIInput | DiscordClientInput | ILog | OpenAIMessageOutput | DiscordClientOutput | MinecraftInput | MinecraftOutput | SchedulerInput | SchedulerOutput | StatusAgentInput | ServiceInput | YoutubeClientOutput | MinebotOutput | MinebotInput | ServiceOutput | TaskInput | TaskTreeState | EmotionType | SkillInfo[] | WebSkillInput | SkillParameters | SkillResult | NotionClientInput | NotionClientOutput | MemberTweetInput | DiscordVoiceMessageOutput | DiscordVoiceResponseInput | DiscordVoiceFillerInput | DiscordVoiceQueueStartInput | DiscordVoiceEnqueueInput | DiscordVoiceQueueEndInput | DiscordVoiceStatusInput;
+    data: TwitterClientInput | TwitterClientOutput | OpenAIInput | DiscordClientInput | ILog | OpenAIMessageOutput | DiscordClientOutput | MinecraftInput | MinecraftOutput | SchedulerInput | SchedulerOutput | StatusAgentInput | ServiceInput | YoutubeClientOutput | MinebotOutput | MinebotInput | ServiceOutput | TaskInput | TaskTreeState | EmotionType | SkillInfo[] | WebSkillInput | SkillParameters | SkillResult | NotionClientInput | NotionClientOutput | MemberTweetInput | DiscordVoiceMessageOutput | DiscordVoiceResponseInput | DiscordVoiceFillerInput | DiscordVoiceQueueStartInput | DiscordVoiceEnqueueInput | DiscordVoiceQueueEndInput | DiscordVoiceStatusInput | MinebotVoiceChatInput | MinebotVoiceResponseOutput;
     targetMemoryZones?: MemoryZone[];
 }
 export interface ILog {

--- a/common/dist/types/eventMap.d.ts
+++ b/common/dist/types/eventMap.d.ts
@@ -7,7 +7,7 @@
 import { ILog, MemoryZone, ServiceInput, ServiceOutput, StatusAgentInput } from './common.js';
 import { DiscordClientInput, DiscordGetServerEmojiInput, DiscordGetServerEmojiOutput, DiscordPlanningInput, DiscordScheduledPostInput, DiscordSendServerEmojiInput, DiscordSendServerEmojiOutput, DiscordSendTextMessageInput, DiscordSendTextMessageOutput } from './discord.js';
 import { SkillInfo } from './llm.js';
-import { MinebotInput, MinebotOutput, SkillParameters, SkillResult } from './minebot.js';
+import { MinebotInput, MinebotOutput, MinebotVoiceChatInput, MinebotVoiceResponseOutput, SkillParameters, SkillResult } from './minebot.js';
 import { MinecraftInput, MinecraftServerName } from './minecraft.js';
 import { NotionClientInput, NotionClientOutput } from './notion.js';
 import { SchedulerInput, SchedulerOutput } from './scheduler.js';
@@ -89,7 +89,7 @@ export interface EventPayloadMap {
     'tool:send_server_emoji': DiscordSendServerEmojiOutput;
 }
 type FallbackEventData = MinebotInput | MinebotOutput | SkillParameters | SkillResult | MinecraftInput | TwitterClientOutput | TwitterActionResult | NotionClientOutput | YoutubeVideoInfoOutput | DiscordGetServerEmojiOutput | DiscordSendServerEmojiOutput;
-export type EventData<T extends string> = T extends keyof EventPayloadMap ? EventPayloadMap[T] : T extends `minecraft:${MinecraftServerName}:${string}` ? MinecraftInput | ServiceInput : T extends `minebot:${string}` ? MinebotInput | MinebotOutput | SkillParameters | SkillResult : T extends `tool:${string}` ? FallbackEventData : unknown;
+export type EventData<T extends string> = T extends keyof EventPayloadMap ? EventPayloadMap[T] : T extends `minecraft:${MinecraftServerName}:${string}` ? MinecraftInput | ServiceInput : T extends `minebot:${string}` ? MinebotInput | MinebotOutput | SkillParameters | SkillResult | MinebotVoiceChatInput | MinebotVoiceResponseOutput : T extends `tool:${string}` ? FallbackEventData : unknown;
 export interface TypedEvent<T extends string = string> {
     type: T;
     memoryZone: MemoryZone;

--- a/common/dist/types/minebot.d.ts
+++ b/common/dist/types/minebot.d.ts
@@ -25,3 +25,14 @@ export type SkillResult = {
     success: boolean;
     result: string;
 };
+export interface MinebotVoiceChatInput {
+    userName: string;
+    message: string;
+    guildId: string;
+    channelId: string;
+}
+export interface MinebotVoiceResponseOutput {
+    guildId: string;
+    channelId: string;
+    responseText: string;
+}

--- a/common/src/types/common.ts
+++ b/common/src/types/common.ts
@@ -16,6 +16,8 @@ import {
   MinebotEventType,
   MinebotInput,
   MinebotOutput,
+  MinebotVoiceChatInput,
+  MinebotVoiceResponseOutput,
   SkillParameters,
   SkillResult,
 } from './minebot.js';
@@ -295,7 +297,9 @@ export interface Event {
   | DiscordVoiceQueueStartInput
   | DiscordVoiceEnqueueInput
   | DiscordVoiceQueueEndInput
-  | DiscordVoiceStatusInput;
+  | DiscordVoiceStatusInput
+  | MinebotVoiceChatInput
+  | MinebotVoiceResponseOutput;
   targetMemoryZones?: MemoryZone[];
 }
 

--- a/common/src/types/eventMap.ts
+++ b/common/src/types/eventMap.ts
@@ -20,6 +20,8 @@ import { SkillInfo } from './llm.js';
 import {
   MinebotInput,
   MinebotOutput,
+  MinebotVoiceChatInput,
+  MinebotVoiceResponseOutput,
   SkillParameters,
   SkillResult,
 } from './minebot.js';
@@ -172,7 +174,7 @@ export type EventData<T extends string> = T extends keyof EventPayloadMap
   : T extends `minecraft:${MinecraftServerName}:${string}`
     ? MinecraftInput | ServiceInput
     : T extends `minebot:${string}`
-      ? MinebotInput | MinebotOutput | SkillParameters | SkillResult
+      ? MinebotInput | MinebotOutput | SkillParameters | SkillResult | MinebotVoiceChatInput | MinebotVoiceResponseOutput
       : T extends `tool:${string}`
         ? FallbackEventData
         : unknown;

--- a/common/src/types/minebot.ts
+++ b/common/src/types/minebot.ts
@@ -31,3 +31,16 @@ export type SkillResult = {
   success: boolean;
   result: string;
 };
+
+export interface MinebotVoiceChatInput {
+  userName: string;
+  message: string;
+  guildId: string;
+  channelId: string;
+}
+
+export interface MinebotVoiceResponseOutput {
+  guildId: string;
+  channelId: string;
+  responseText: string;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the Discord voice pipeline and EventBus routing; failures could break voice responses or leave queues/status in a bad state, though changes are mostly additive and scoped behind a per-guild mode toggle.
> 
> **Overview**
> Adds a per-guild `voice_mode` toggle (`chat` vs `minebot`) in the Discord bot and exposes helpers (`getVoiceMode`, `getActiveVoiceInfo`) to support voice routing.
> 
> When `minebot` mode is enabled, Discord voice transcription in `LLMService` is routed to a new `minebot:voice_chat` EventBus flow; Minebot generates a text response which is sent back as `minebot:voice_response`, converted to TTS, enqueued into the existing Discord voice queue, and finalized via `discord:voice_queue_end`.
> 
> Updates Minebot to support this flow (Discord→Minecraft name resolution mapping, FCA callback `setOnResponseText` to capture generated text), and extends shared `@shannon/common` types/event typing for the new Minebot voice events.
> 
> Separately, several LLM agents/memory services switch model initialization to support Gemini/reasoning-model token/timeout settings and API key selection, replacing the prior fallback setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02262a1508d800959753260e3fd56e0a90ba6829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->