### PR TITLE
minebot関連修正

### DIFF
--- a/backend/src/services/minebot/constantSkills/autoEat.ts
+++ b/backend/src/services/minebot/constantSkills/autoEat.ts
@@ -12,15 +12,13 @@ class AutoEat extends ConstantSkill {
     super(bot);
     this.skillName = 'auto-eat';
     this.description = '体力または満腹度が低い時に自動で食べ物を食べます';
-    this.interval = 1000; // 1秒ごとにチェック
+    this.interval = 1000;
     this.isLocked = false;
-    this.status = false;
+    this.status = true;
     this.priority = 5;
   }
 
   async runImpl() {
-    // 既に食べている場合はスキップ
-    if (this.bot.pathfinder.isMoving()) return;
 
     // 体力または満腹度が低い場合に食べる
     const health = this.bot.health;

--- a/backend/src/services/minebot/instantSkills/checkContainer.ts
+++ b/backend/src/services/minebot/instantSkills/checkContainer.ts
@@ -133,7 +133,7 @@ class CheckContainer extends InstantSkill {
 
                 return {
                     success: true,
-                    result: `${block.name}の中身（${usedSlots}/${totalSlots}スロット使用、計${totalItems}個）: ${itemList}`,
+                    result: `${block.name}(${x}, ${y}, ${z})の中身（${usedSlots}/${totalSlots}スロット使用、計${totalItems}個）: ${itemList}`,
                 };
             } catch (error: any) {
                 container.close();

--- a/backend/src/services/minebot/instantSkills/checkFurnace.ts
+++ b/backend/src/services/minebot/instantSkills/checkFurnace.ts
@@ -87,7 +87,7 @@ class CheckFurnace extends InstantSkill {
         if (fuelItem) {
           slots.push(`燃料: ${fuelItem.name} x${fuelItem.count}`);
         } else {
-          slots.push('燃料: なし');
+          slots.push('燃料: なし（石炭か木炭を入れてください）');
         }
 
         if (outputItem) {

--- a/backend/src/services/minebot/instantSkills/digBlockAt.ts
+++ b/backend/src/services/minebot/instantSkills/digBlockAt.ts
@@ -30,10 +30,16 @@ class DigBlockAt extends InstantSkill {
         description: 'Z座標',
         required: true,
       },
+      {
+        name: 'collect',
+        type: 'boolean',
+        description: '掘削後にドロップアイテムを自動回収するか（デフォルト: true）。連続で複数ブロック掘る場合はfalseにして最後にpickup-nearest-itemで回収すると効率的',
+        default: true,
+      },
     ];
   }
 
-  async runImpl(x: number, y: number, z: number) {
+  async runImpl(x: number, y: number, z: number, collect: boolean = true) {
     try {
       // パラメータチェック
       if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
@@ -108,10 +114,18 @@ class DigBlockAt extends InstantSkill {
       }
 
       const blockName = block.name;
+
+      const beforeItems = new Map<string, number>();
+      if (collect) {
+        for (const item of this.bot.inventory.items()) {
+          beforeItems.set(item.name, (beforeItems.get(item.name) || 0) + item.count);
+        }
+      }
+
       await this.bot.dig(block);
 
-      // 掘れたかどうかを確認（同じ座標のブロックがなくなっているか）
-      await new Promise(resolve => setTimeout(resolve, 100)); // 少し待つ
+      // 掘削完了を確認
+      await new Promise(resolve => setTimeout(resolve, 200));
       const afterBlock = this.bot.blockAt(pos);
 
       if (afterBlock && afterBlock.name !== 'air' && afterBlock.name !== 'cave_air' && afterBlock.name === blockName) {
@@ -121,9 +135,25 @@ class DigBlockAt extends InstantSkill {
         };
       }
 
+      if (!collect) {
+        return {
+          success: true,
+          result: `${blockName}を掘りました（回収スキップ）`,
+        };
+      }
+
+      const collected = await this.waitForCollection(beforeItems, 2000);
+
+      if (collected.length > 0) {
+        return {
+          success: true,
+          result: `${blockName}を掘りました。${collected.join(', ')}を回収`,
+        };
+      }
+
       return {
         success: true,
-        result: `${blockName}を掘りました。ドロップしたアイテムを拾うにはpickup-nearest-item {}を実行してください`,
+        result: `${blockName}を掘りました（ドロップ未回収 — 足元にない可能性）`,
       };
     } catch (error: any) {
       // エラーメッセージを詳細化
@@ -141,6 +171,37 @@ class DigBlockAt extends InstantSkill {
         result: `掘削エラー: ${errorDetail}`,
       };
     }
+  }
+
+  /**
+   * インベントリの増分を最大 timeoutMs 待って検出する。
+   * 200ms 間隔でポーリングし、増えた分を返す。
+   */
+  private async waitForCollection(
+    beforeItems: Map<string, number>,
+    timeoutMs: number,
+  ): Promise<string[]> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 200));
+      const diff = this.inventoryDiff(beforeItems);
+      if (diff.length > 0) return diff;
+    }
+    return [];
+  }
+
+  private inventoryDiff(beforeItems: Map<string, number>): string[] {
+    const result: string[] = [];
+    for (const item of this.bot.inventory.items()) {
+      const before = beforeItems.get(item.name) || 0;
+      const current = (this.bot.inventory.items()
+        .filter(i => i.name === item.name)
+        .reduce((sum, i) => sum + i.count, 0));
+      if (current > before && !result.some(r => r.startsWith(item.name))) {
+        result.push(`${item.name}x${current - before}`);
+      }
+    }
+    return result;
   }
 
   /**

--- a/backend/src/services/minebot/instantSkills/findBlocks.ts
+++ b/backend/src/services/minebot/instantSkills/findBlocks.ts
@@ -1,8 +1,12 @@
 import minecraftData from 'minecraft-data';
 import { CustomBot, InstantSkill } from '../types.js';
 
+const INITIAL_RADIUS = 16;
+const RADIUS_STEP = 16;
+
 /**
  * 原子的スキル: 周囲のブロックを検索
+ * 近距離から段階的に範囲を広げて検索する。
  */
 class FindBlocks extends InstantSkill {
   private mcData: any;
@@ -49,11 +53,15 @@ class FindBlocks extends InstantSkill {
         };
       }
 
-      const blocks = this.bot.findBlocks({
-        matching: blockType.id,
-        maxDistance: maxDistance,
-        count: count,
-      });
+      let blocks: any[] = [];
+      for (let radius = INITIAL_RADIUS; radius <= maxDistance; radius += RADIUS_STEP) {
+        blocks = this.bot.findBlocks({
+          matching: blockType.id,
+          maxDistance: radius,
+          count: count,
+        });
+        if (blocks.length >= count) break;
+      }
 
       if (blocks.length === 0) {
         return {
@@ -62,7 +70,7 @@ class FindBlocks extends InstantSkill {
         };
       }
 
-      // 距離順にソート
+      const botPos = this.bot.entity.position;
       const sortedBlocks = blocks
         .map((pos) => {
           const blockData: any = {
@@ -70,10 +78,9 @@ class FindBlocks extends InstantSkill {
             y: pos.y,
             z: pos.z,
             distance:
-              Math.floor(this.bot.entity.position.distanceTo(pos) * 10) / 10,
+              Math.floor(botPos.distanceTo(pos) * 10) / 10,
           };
 
-          // farmlandの場合は上のブロックを確認
           if (blockName === 'farmland') {
             const aboveBlock = this.bot.blockAt(pos.offset(0, 1, 0));
             if (aboveBlock && aboveBlock.name !== 'air') {
@@ -85,7 +92,6 @@ class FindBlocks extends InstantSkill {
         })
         .sort((a, b) => a.distance - b.distance);
 
-      // farmlandの場合は空きと埋まっているものを分けて表示
       if (blockName === 'farmland') {
         const emptyFarmland = sortedBlocks.filter((b) => !b.above);
         const occupiedFarmland = sortedBlocks.filter((b) => b.above);
@@ -108,21 +114,17 @@ class FindBlocks extends InstantSkill {
           result += `、使用中${occupiedCount}個`;
         }
 
-        return {
-          success: true,
-          result,
-        };
+        return { success: true, result };
       }
 
       const blockList = sortedBlocks
-        .slice(0, 5) // 最初の5個だけ表示
+        .slice(0, 5)
         .map((b) => `(${b.x}, ${b.y}, ${b.z}) 距離${b.distance}m`)
         .join(', ');
 
       return {
         success: true,
-        result: `${blockName}を${blocks.length}個発見: ${blockList}${blocks.length > 5 ? '...' : ''
-          }`,
+        result: `${blockName}を${blocks.length}個発見: ${blockList}${blocks.length > 5 ? '...' : ''}`,
       };
     } catch (error: any) {
       return {

--- a/backend/src/services/minebot/instantSkills/findNearestEntity.ts
+++ b/backend/src/services/minebot/instantSkills/findNearestEntity.ts
@@ -1,4 +1,7 @@
 import { CustomBot, InstantSkill } from '../types.js';
+import { createLogger } from '../../../utils/logger.js';
+
+const log = createLogger('Minebot:Skill:findEntity');
 
 /**
  * 原子的スキル: 最も近いエンティティを検索
@@ -27,14 +30,18 @@ class FindNearestEntity extends InstantSkill {
 
   async runImpl(entityType: string | null = null, maxDistance: number = 64) {
     try {
+      if (entityType?.toLowerCase() === 'player') {
+        return this.findNearestPlayer(maxDistance);
+      }
+
       const entity = this.bot.nearestEntity((e) => {
         if (e.position.distanceTo(this.bot.entity.position) > maxDistance) {
           return false;
         }
         if (entityType) {
-          return e.name?.toLowerCase() === entityType.toLowerCase();
+          const lower = entityType.toLowerCase();
+          return e.name?.toLowerCase() === lower || e.type?.toLowerCase() === lower;
         }
-        // 自分自身は除外
         return e !== this.bot.entity;
       });
 
@@ -63,6 +70,68 @@ class FindNearestEntity extends InstantSkill {
         result: `検索エラー: ${error.message}`,
       };
     }
+  }
+
+  private findNearestPlayer(maxDistance: number) {
+    const botPos = this.bot.entity.position;
+    let nearest: { username: string; distance: number; pos: any } | null = null;
+
+    // 1) bot.players API
+    const playerNames = Object.keys(this.bot.players);
+    log.debug(`bot.players: ${playerNames.length}人 [${playerNames.join(', ')}]`);
+
+    for (const player of Object.values(this.bot.players)) {
+      if (player.username === this.bot.username) continue;
+      if (!player.entity) {
+        log.debug(`  ${player.username}: entity=null (tab listのみ)`);
+        continue;
+      }
+      const dist = player.entity.position.distanceTo(botPos);
+      log.debug(`  ${player.username}: entity有, dist=${dist.toFixed(1)}`);
+      if (dist > maxDistance) continue;
+      if (!nearest || dist < nearest.distance) {
+        nearest = {
+          username: player.username,
+          distance: Math.floor(dist * 10) / 10,
+          pos: player.entity.position,
+        };
+      }
+    }
+
+    // 2) bot.players で見つからなかった場合、bot.entities から player タイプを探す
+    if (!nearest) {
+      log.debug('bot.players にエンティティなし → bot.entities をフォールバック検索');
+      const allEntities = Object.values(this.bot.entities);
+      log.debug(`bot.entities: ${allEntities.length}個`);
+
+      for (const e of allEntities) {
+        if (e === this.bot.entity) continue;
+        if (e.type !== 'player') continue;
+        const dist = e.position.distanceTo(botPos);
+        log.debug(`  entity player "${e.username ?? e.name}": dist=${dist.toFixed(1)}`);
+        if (dist > maxDistance) continue;
+        if (!nearest || dist < nearest.distance) {
+          nearest = {
+            username: (e as any).username || e.name || 'unknown',
+            distance: Math.floor(dist * 10) / 10,
+            pos: e.position,
+          };
+        }
+      }
+    }
+
+    if (!nearest) {
+      log.warn(`${maxDistance}ブロック以内にプレイヤー未検出`);
+      return {
+        success: true,
+        result: `${maxDistance}ブロック以内にplayerタイプのエンティティは見つかりませんでした`,
+      };
+    }
+
+    return {
+      success: true,
+      result: `${nearest.username}を発見: 座標(${Math.floor(nearest.pos.x)}, ${Math.floor(nearest.pos.y)}, ${Math.floor(nearest.pos.z)}), 距離${nearest.distance}m`,
+    };
   }
 }
 

--- a/backend/src/services/minebot/instantSkills/startSmelting.ts
+++ b/backend/src/services/minebot/instantSkills/startSmelting.ts
@@ -111,7 +111,7 @@ class StartSmelting extends InstantSkill {
       if (fuelItems.length === 0) {
         return {
           success: false,
-          result: `燃料${fuelItem}を持っていません`,
+          result: `燃料${fuelItem}を持っていません。石炭か木炭を入れてください。`,
         };
       }
 

--- a/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
+++ b/backend/src/services/minebot/llm/graph/nodes/FunctionCallingAgent.ts
@@ -13,6 +13,7 @@ import { models } from '../../../../../config/models.js';
 import { createLogger } from '../../../../../utils/logger.js';
 import { createTracedModel } from '../../../../llm/utils/langfuse.js';
 import { CONFIG } from '../../../config/MinebotConfig.js';
+import { WorldKnowledgeService } from '../../../knowledge/WorldKnowledgeService.js';
 import { CustomBot } from '../../../types.js';
 import { CentralLogManager, LogManager } from '../logging/index.js';
 import { UpdatePlanTool } from '../tools/UpdatePlanTool.js';
@@ -230,7 +231,7 @@ export class FunctionCallingAgent {
     }
 
     // メッセージ構築
-    const systemPrompt = this.buildSystemPrompt();
+    const systemPrompt = await this.buildSystemPrompt();
     const messages: BaseMessage[] = [
       new SystemMessage(systemPrompt),
     ];
@@ -686,13 +687,22 @@ export class FunctionCallingAgent {
    * 新方式ではツール情報は API の tools パラメータで渡すため、
    * プロンプトは ~800文字に削減。
    */
-  private buildSystemPrompt(): string {
+  private async buildSystemPrompt(): Promise<string> {
     const env = this.gatherEnvironmentContext();
 
     const entity = this.bot.entity as any;
     const health = this.bot.health || 0;
     const food = this.bot.food || 0;
     const pos = entity?.position || { x: 0, y: 0, z: 0 };
+
+    let worldKnowledgeStr = '';
+    try {
+      const wk = WorldKnowledgeService.getInstance(this.bot.connectedServerName || 'default');
+      worldKnowledgeStr = await wk.buildContextForPosition(
+        { x: Math.round(pos.x), y: Math.round(pos.y), z: Math.round(pos.z) },
+        128,
+      );
+    } catch { }
 
     const inventory =
       this.bot.inventory
@@ -741,14 +751,35 @@ export class FunctionCallingAgent {
 - 向き: ${env.facing.direction}${senderStr}${entitiesStr}
 
 ## ルール
-1. **タスク全体を把握してから行動する**。判断を求められたら自分で決めて即行動（聞き返さない）
+1. **タスク全体を把握してから行動する**。必要な素材を全て洗い出してから行動開始
 2. 複雑なタスク（3ステップ以上）はupdate-planで計画→実行
-3. 行動する前にまず状況を確認する（find-blocks, check-inventory等）
+3. **素材調達の優先順位**: インベントリ確認 → 近くのチェスト(find-blocks("chest")→check-container→withdraw-from-container) → ブロック採掘。
+  - ワールド知識に既知のチェストがあればそこから取る。なければfind-blocks("chest")で近くのチェストを探す。
 4. ブロック/コンテナ操作は近距離(3m以内)で。遠い場合はmove-toで近づく
-5. 失敗したら同じことを繰り返さない。2回同じエラーが出たら方針転換
+  - 特に作業台。作業台は既存のものがあればそれを使う。
+5. **失敗したら同じことを繰り返さない**。2回同じエラーが出たら方針転換
 6. 具体的なブロック名を使う（"log"→"oak_log", "planks"→"oak_planks"）
 7. stone→cobblestoneがドロップ。木材の種類を合わせる（oak_log→oak_planks）
-8. **プレイヤーの場所に移動する時**: 「話しかけてきた人」の座標が表示されていればmove-to。不明ならfind-nearest-entity(entityType="player")で取得してからmove-to。**絶対に座標を推測しない**`;
+8. **プレイヤーの場所に移動する時**: 「話しかけてきた人」の座標が表示されていればmove-to。不明ならfind-nearest-entity(entityType="player")で取得してからmove-to。**絶対に座標を推測しない**
+9. **素材集めは一度にまとめる**。同じ場所のブロックは連続で掘る。1個掘って別のことをしない
+
+## ツール進行（下位ツールがないと上位素材が掘れない）
+- **素手**: 木(log), 土(dirt), 砂(sand), 草 のみ掘れる
+- **木のピッケル**: stone, cobblestone, 石炭鉱石が掘れる
+- **石のピッケル**: 鉄鉱石が掘れる
+- **鉄のピッケル**: ダイヤ鉱石, 金鉱石が掘れる
+- **stone/cobblestoneを掘るには最低でも木のピッケルが必要**
+
+## クラフト依存チェーン（素材が足りない時は最下層から逆算して揃える）
+- crafting_table ← planks x4 ← log x1
+- planks ← 任意のlog (oak_log, birch_log等)。**草や土からは得られない**
+- stick ← planks x2
+- wooden_pickaxe ← planks x3 + stick x2 + crafting_table
+- stone_pickaxe ← cobblestone x3 + stick x2 + crafting_table（木のピッケルで石を掘ってから）
+- 例: stone_pickaxeが欲しい → log x3以上を集める → planks → stick + crafting_table + wooden_pickaxe → stoneを掘る → stone_pickaxe
+
+## ワールド知識
+${worldKnowledgeStr}`;
   }
 
   /**

--- a/backend/src/services/minebot/skillAgent.ts
+++ b/backend/src/services/minebot/skillAgent.ts
@@ -335,10 +335,21 @@ export class SkillAgent {
    * 送信者情報を更新
    */
   private updateSenderInfo(username: string): void {
-    const sender = this.bot.players[username]?.entity;
     this.bot.environmentState.senderName = username;
 
-    const position = sender ? sender.position : null;
+    // bot.players → bot.entities の順でプレイヤーエンティティを探す
+    let position = this.bot.players[username]?.entity?.position ?? null;
+
+    if (!position) {
+      for (const e of Object.values(this.bot.entities)) {
+        if (e === this.bot.entity) continue;
+        if (e.type === 'player' && ((e as any).username === username || e.name === username)) {
+          position = e.position;
+          break;
+        }
+      }
+    }
+
     if (position) {
       this.bot.environmentState.senderPosition = new Vec3(
         Number(position.x.toFixed(1)),
@@ -346,6 +357,7 @@ export class SkillAgent {
         Number(position.z.toFixed(1))
       );
     } else {
+      log.warn(`updateSenderInfo: ${username} のエンティティが見つかりません (players.entity=null, entities fallback失敗)`);
       this.bot.environmentState.senderPosition = null;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Behavior changes affect autonomous actions (auto-eat default enabled, digging now optionally auto-collects, player/entity lookup logic changed) and the LLM system prompt is expanded with world knowledge, which may alter planning and increase latency/token usage.
> 
> **Overview**
> Minebot skills were tuned to be more autonomous and informative: `auto-eat` is now enabled by default and no longer skips while the bot is moving, and several instant-skill responses were improved (e.g., `check-container` includes coordinates; furnace-related messages guide users toward coal/charcoal).
> 
> `dig-block-at` adds a new `collect` parameter (default `true`) that waits briefly after digging and detects inventory deltas to report/confirm automatic drop collection, with clearer success/failure messaging when drops aren’t picked up.
> 
> Entity/block discovery and LLM guidance were strengthened: `find-blocks` now expands search radius in steps up to `maxDistance`, `find-nearest-entity` adds robust `player` lookup with `bot.players`→`bot.entities` fallback, `skillAgent.updateSenderInfo` uses the same fallback for sender position, and `FunctionCallingAgent` now builds its system prompt asynchronously, injecting `WorldKnowledgeService` context plus stricter material-gathering/tool-progression rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 511295088fffd52777bef86160f6d59de8cdff25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->